### PR TITLE
Enhance Torznab indexer support

### DIFF
--- a/backend/src/controllers/IndexerController.ts
+++ b/backend/src/controllers/IndexerController.ts
@@ -4,24 +4,40 @@ import { hashToFakeMagnet } from './qbittorrentMappings';
 import { MediaProviderService, MediaSearchResult } from '../services/mediaprovider';
 
 /**
- * IndexerController provides a Torznab-compatible API for Sonarr and Radarr.
+ * IndexerController provides a Torznab-compatible API for Sonarr, Radarr and Lidarr.
  */
 export class IndexerController {
 	private readonly mediaProviderService = container.get(MediaProviderService);
 
 	handle = async (req: Request, res: Response) => {
-		const { t, q, season, ep, offset, limit, cat, imdbid, rid, director, year } = req.query;
+		const { t, q, season, ep, offset, limit, cat, imdbid, rid, director, year, artist, album } = req.query;
 
-		console.log(`[Indexer] Action: ${t}, Query: ${q}, IMDB: ${imdbid}, Cat: ${cat}`);
+		console.log(`[Indexer] Action: ${t}, Query: ${q}, IMDB: ${imdbid}, Artist: ${artist}, Album: ${album}, Cat: ${cat}`);
 
 		if (t === 'caps') {
 			return this.getCapabilities(res);
 		}
 
-		if (t === 'search' || t === 'tvsearch' || t === 'movie') {
-			// If `t` is missing, return a single fake item so clients (Radarr/Sonarr) receive at least one result.
-			if (!q && !imdbid) {
-				console.log('[Indexer] No query `q` nor `imdbid` provided — returning one fake item for compatibility');
+		if (t === 'search' || t === 'tvsearch' || t === 'movie' || t === 'music') {
+			// Music search (Lidarr): build the query from the structured
+			// artist/album params (Lidarr prefers them over free-text `q`
+			// when the caps advertise audio-search support). Values are
+			// trimmed; for self-titled albums Lidarr sends artist == album,
+			// deduped case-insensitively to avoid "X X" queries.
+			let musicQuery = '';
+			if (t === 'music') {
+				const parts = [artist, album]
+					.flat()
+					.filter((v): v is string => typeof v === 'string' && v.trim() !== '')
+					.map((v) => v.trim());
+				musicQuery = parts.filter((p, i) => parts.findIndex((x) => x.toLowerCase() === p.toLowerCase()) === i).join(' ');
+			}
+
+			// If no search terms at all, return a single fake item so clients
+			// (Radarr/Sonarr/Lidarr) receive at least one result: their
+			// connection Test fails hard on an empty feed.
+			if (!q && !imdbid && !musicQuery) {
+				console.log('[Indexer] No search terms provided (q/imdbid/artist/album) — returning one fake item for compatibility');
 				const fakeItem = [
 					{
 						name: 'Mularr Test Item',
@@ -36,6 +52,12 @@ export class IndexerController {
 			}
 
 			let queryStr = (q as string) || '';
+
+			// Lidarr sends a literal empty `q=` alongside artist/album —
+			// fall back to the structured params whenever q is blank.
+			if (t === 'music' && !queryStr.trim()) {
+				queryStr = musicQuery;
+			}
 
 			// If no 'q' but has metadata (Radarr/Sonarr often do this first)
 			if (!queryStr && imdbid) {
@@ -90,13 +112,27 @@ export class IndexerController {
 
 	private getCapabilities(res: Response) {
 		res.header('Content-Type', 'application/xml');
+		// The search elements MUST live inside <searching> — the *arr caps
+		// parsers (shared NzbDrone.Core lineage) read xmlRoot.Element("searching")
+		// and ignore search elements placed anywhere else, silently falling
+		// back to their built-in defaults. Element names per those parsers:
+		// Lidarr reads "audio-search" (NOT "music-search" — kept below as the
+		// Jackett-convention alias for other consumers), Sonarr "tv-search",
+		// Radarr "movie-search". movie-search deliberately advertises only
+		// "q" (we return empty for imdbid-only queries, so advertising imdbid
+		// would make Radarr prefer an always-empty search tier); tv-search
+		// omits "rid" for the same reason.
 		const caps = `<?xml version="1.0" encoding="UTF-8"?>
 <caps>
-  <server title="Mularr" description="aMule Indexer for Sonarr/Radarr" />
+  <server title="Mularr" description="aMule Indexer for Sonarr/Radarr/Lidarr" />
   <limits max="100" default="50" />
-  <search available="yes" supportedParams="q" />
-  <tv-search available="yes" supportedParams="q,season,ep" />
-  <movie-search available="yes" supportedParams="q,imdbid" />
+  <searching>
+    <search available="yes" supportedParams="q" />
+    <tv-search available="yes" supportedParams="q,season,ep" />
+    <movie-search available="yes" supportedParams="q" />
+    <audio-search available="yes" supportedParams="q,artist,album" />
+    <music-search available="yes" supportedParams="q,artist,album" />
+  </searching>
   <categories>
     <category id="2000" name="Movies">
       <subcat id="2010" name="Foreign" />
@@ -105,6 +141,11 @@ export class IndexerController {
     <category id="5000" name="TV">
       <subcat id="5030" name="Foreign" />
       <subcat id="5040" name="HD" />
+    </category>
+    <category id="3000" name="Audio">
+      <subcat id="3010" name="MP3" />
+      <subcat id="3030" name="Audiobook" />
+      <subcat id="3040" name="Lossless" />
     </category>
   </categories>
 </caps>`;
@@ -147,7 +188,7 @@ export class IndexerController {
 <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
   <channel>
     <title>Mularr Indexer</title>
-    <description>aMule search results for Sonarr/Radarr</description>
+    <description>aMule search results for Sonarr/Radarr/Lidarr</description>
     <torznab:response offset="${offset}" total="${total}" />
     ${itemsXml}
   </channel>

--- a/backend/src/controllers/IndexerController.ts
+++ b/backend/src/controllers/IndexerController.ts
@@ -68,11 +68,21 @@ export class IndexerController {
 				return this.renderRss(res, [], cat as string);
 			}
 
-			// If it's a TV search, add season/ep to query
-			if (t === 'tvsearch') {
-				if (season) queryStr += ` S${season.toString().padStart(2, '0')}`;
-				if (ep) queryStr += ` E${ep.toString().padStart(2, '0')}`;
-			}
+			// tvsearch: search by the title Sonarr put in `q` and nothing
+			// else. season/ep arrive as separate Torznab params, NOT inside
+			// `q` — appending them to the eD2k query (in any token form)
+			// only narrows it against the network's inconsistent episode
+			// naming and loses real content. The episode, language and
+			// quality matching is Sonarr's job: it parses each returned
+			// release name and rejects what doesn't fit (verified against
+			// Sonarr's search decision specs). So leave `q` as formatted and
+			// let the candidates flow back. (season/ep stay destructured for
+			// logging/clarity but are intentionally unused.)
+			//
+			// Trade-off: a tvsearch returns every episode's releases for the
+			// show. Automatic search is unaffected (only matches are grabbed);
+			// interactive search shows the non-matching ones greyed-out with a
+			// "Wrong episode" rejection — noisier list, but never grabbable.
 
 			// Radarr/Sonarr "Test" often sends 't=movie' or 't=search' without 'q'.
 			if (!queryStr.trim()) {
@@ -83,11 +93,40 @@ export class IndexerController {
 			try {
 				await this.mediaProviderService.startSearch(queryStr);
 
-				while (true) {
-					const searchStatus = await this.mediaProviderService.getSearchStatus();
-					console.log(`[Indexer] Search progress: ${Math.floor(searchStatus.progress * 100)}%`);
-					await new Promise((r) => setTimeout(r, 1000));
-					if (searchStatus.progress >= 1) break;
+				// Gather results until the set stops growing, not just until
+				// the EC "progress" hits 100%. progress reaches 1 as soon as
+				// the search is dispatched and the first responses land, but a
+				// global eD2k search keeps trickling results back for many
+				// seconds after that — returning at progress>=1 yields a small,
+				// non-deterministic early snapshot (observed: ~17 vs ~126 for
+				// the same query given more time), which silently drops
+				// long-tail releases (minority languages, rarer rips).
+				//
+				// Tuned for completeness ("fuller" over "faster"): poll the
+				// accumulating result set and only stop once its size has been
+				// stable across STABLE_POLLS consecutive polls AND the search
+				// reports done, or once MAX_WAIT_MS elapses. No early-exit on a
+				// result-count threshold — we want the full set, accepting up
+				// to ~MAX_WAIT_MS of latency on interactive searches (well
+				// within Sonarr/Radarr's request timeout).
+				const POLL_MS = 1500;
+				const MAX_WAIT_MS = 12000;
+				const STABLE_POLLS = 3;
+				const startedAt = Date.now();
+				let lastCount = -1;
+				let stable = 0;
+				while (Date.now() - startedAt < MAX_WAIT_MS) {
+					await new Promise((r) => setTimeout(r, POLL_MS));
+					const status = await this.mediaProviderService.getSearchStatus();
+					const current = (await this.mediaProviderService.getSearchResults()).list.length;
+					if (current === lastCount) {
+						stable++;
+						if (status.progress >= 1 && stable >= STABLE_POLLS) break;
+					} else {
+						stable = 0;
+					}
+					lastCount = current;
+					console.log(`[Indexer] Search progress: ${Math.floor(status.progress * 100)}%, results so far: ${current}`);
 				}
 
 				const results = await this.mediaProviderService.getSearchResults();

--- a/backend/src/controllers/IndexerController.ts
+++ b/backend/src/controllers/IndexerController.ts
@@ -20,10 +20,9 @@ export class IndexerController {
 
 		if (t === 'search' || t === 'tvsearch' || t === 'movie' || t === 'music') {
 			// Music search (Lidarr): build the query from the structured
-			// artist/album params (Lidarr prefers them over free-text `q`
-			// when the caps advertise audio-search support). Values are
-			// trimmed; for self-titled albums Lidarr sends artist == album,
-			// deduped case-insensitively to avoid "X X" queries.
+			// artist/album params (Lidarr prefers them over free-text `q`).
+			// Values are trimmed and deduped case-insensitively, since
+			// self-titled albums arrive as artist == album.
 			let musicQuery = '';
 			if (t === 'music') {
 				const parts = [artist, album]
@@ -33,8 +32,7 @@ export class IndexerController {
 				musicQuery = parts.filter((p, i) => parts.findIndex((x) => x.toLowerCase() === p.toLowerCase()) === i).join(' ');
 			}
 
-			// If no search terms at all, return a single fake item so clients
-			// (Radarr/Sonarr/Lidarr) receive at least one result: their
+			// With no search terms, return one fake item: the *arr
 			// connection Test fails hard on an empty feed.
 			if (!q && !imdbid && !musicQuery) {
 				console.log('[Indexer] No search terms provided (q/imdbid/artist/album) — returning one fake item for compatibility');
@@ -68,21 +66,14 @@ export class IndexerController {
 				return this.renderRss(res, [], cat as string);
 			}
 
-			// tvsearch: search by the title Sonarr put in `q` and nothing
-			// else. season/ep arrive as separate Torznab params, NOT inside
-			// `q` — appending them to the eD2k query (in any token form)
-			// only narrows it against the network's inconsistent episode
-			// naming and loses real content. The episode, language and
-			// quality matching is Sonarr's job: it parses each returned
-			// release name and rejects what doesn't fit (verified against
-			// Sonarr's search decision specs). So leave `q` as formatted and
-			// let the candidates flow back. (season/ep stay destructured for
-			// logging/clarity but are intentionally unused.)
-			//
-			// Trade-off: a tvsearch returns every episode's releases for the
-			// show. Automatic search is unaffected (only matches are grabbed);
-			// interactive search shows the non-matching ones greyed-out with a
-			// "Wrong episode" rejection — noisier list, but never grabbable.
+			// tvsearch: search by the title in `q` only. season/ep arrive as
+			// separate Torznab params, not inside `q`; appending them narrows
+			// the eD2k query against the network's inconsistent episode naming
+			// and loses real content. Sonarr does the episode/language/quality
+			// matching itself, rejecting releases that don't fit, so we let all
+			// candidates flow back. (season/ep stay destructured for logging.)
+			// Trade-off: a tvsearch returns every episode's releases; automatic
+			// search only grabs matches, interactive greys out the rest.
 
 			// Radarr/Sonarr "Test" often sends 't=movie' or 't=search' without 'q'.
 			if (!queryStr.trim()) {
@@ -93,22 +84,15 @@ export class IndexerController {
 			try {
 				await this.mediaProviderService.startSearch(queryStr);
 
-				// Gather results until the set stops growing, not just until
-				// the EC "progress" hits 100%. progress reaches 1 as soon as
-				// the search is dispatched and the first responses land, but a
-				// global eD2k search keeps trickling results back for many
-				// seconds after that — returning at progress>=1 yields a small,
-				// non-deterministic early snapshot (observed: ~17 vs ~126 for
-				// the same query given more time), which silently drops
-				// long-tail releases (minority languages, rarer rips).
-				//
-				// Tuned for completeness ("fuller" over "faster"): poll the
-				// accumulating result set and only stop once its size has been
-				// stable across STABLE_POLLS consecutive polls AND the search
-				// reports done, or once MAX_WAIT_MS elapses. No early-exit on a
-				// result-count threshold — we want the full set, accepting up
-				// to ~MAX_WAIT_MS of latency on interactive searches (well
-				// within Sonarr/Radarr's request timeout).
+				// Gather until the result set stops growing, not just until EC
+				// progress hits 100%. progress reaches 1 as soon as the first
+				// responses land, but a global eD2k search keeps trickling
+				// results for many seconds; returning early yields a small,
+				// non-deterministic snapshot (observed ~17 vs ~126) that drops
+				// long-tail releases. So poll the set and stop only once its
+				// size is stable across STABLE_POLLS polls AND the search
+				// reports done, or MAX_WAIT_MS elapses — favouring completeness
+				// over speed, within the *arr request timeout.
 				const POLL_MS = 1500;
 				const MAX_WAIT_MS = 12000;
 				const STABLE_POLLS = 3;
@@ -151,16 +135,13 @@ export class IndexerController {
 
 	private getCapabilities(res: Response) {
 		res.header('Content-Type', 'application/xml');
-		// The search elements MUST live inside <searching> — the *arr caps
-		// parsers (shared NzbDrone.Core lineage) read xmlRoot.Element("searching")
-		// and ignore search elements placed anywhere else, silently falling
-		// back to their built-in defaults. Element names per those parsers:
-		// Lidarr reads "audio-search" (NOT "music-search" — kept below as the
-		// Jackett-convention alias for other consumers), Sonarr "tv-search",
-		// Radarr "movie-search". movie-search deliberately advertises only
-		// "q" (we return empty for imdbid-only queries, so advertising imdbid
-		// would make Radarr prefer an always-empty search tier); tv-search
-		// omits "rid" for the same reason.
+		// Search elements MUST live inside <searching> — the *arr caps parsers
+		// (shared NzbDrone.Core lineage) only read elements there and otherwise
+		// fall back to built-in defaults. Names per those parsers: Lidarr
+		// "audio-search" ("music-search" kept as a Jackett alias), Sonarr
+		// "tv-search", Radarr "movie-search". movie-search advertises only "q"
+		// (imdbid-only queries return empty, so advertising imdbid would make
+		// Radarr prefer an always-empty tier); tv-search omits "rid" likewise.
 		const caps = `<?xml version="1.0" encoding="UTF-8"?>
 <caps>
   <server title="Mularr" description="aMule Indexer for Sonarr/Radarr/Lidarr" />

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -86,7 +86,7 @@ export class QbittorrentController {
 		const config = await this.amuledService.getConfig();
 		const categories = await this.amuleService.getCategories();
 		const transfers = await this.mediaProviderService.getTransfers();
-		// Sonarr sends the 40-hex btih we advertised; match it back to the eD2k transfer.
+		// Sonarr sends the 40-hex btih we advertised; match it back to the transfer.
 		const tr = transfers.list.find((t) => clientHashMatchesMularrHash(t.hash, hash));
 
 		if (tr) {
@@ -137,7 +137,7 @@ export class QbittorrentController {
 			return res.status(400).send('Setting category for all torrents is not supported');
 		}
 		const hashList = hashes.split('|');
-		// Resolve the btih(s) Sonarr sends back to eD2k hashes (one transfers fetch).
+		// Resolve the btih(s) Sonarr sends back to transfer hashes (one fetch).
 		const transfers = await this.mediaProviderService.getTransfers();
 		for (const hash of hashList) {
 			if (!hash) continue;
@@ -205,11 +205,11 @@ export class QbittorrentController {
 				}
 
 				return {
-					// Report the 40-hex btih (sha1 of the eD2k hash), NOT the raw
-					// eD2k hash: it must equal the infohash in the magnet Sonarr
+					// Report the 40-hex btih (sha1 of the transfer hash), not the
+					// raw hash: it must equal the infohash in the magnet Sonarr
 					// grabbed, or Sonarr can't match this download to its queue
-					// entry (→ no progress, no import). The validator calls above
-					// still use the real eD2k t.hash internally.
+					// entry (no progress, no import). The validator calls above
+					// still use the real t.hash internally.
 					hash: t.hash ? hashToBtih(t.hash) : 'unknown',
 					name: t.name || 'Unknown',
 					size: t.size || 0,
@@ -225,14 +225,12 @@ export class QbittorrentController {
 					added_on: Math.floor(Date.now() / 1000),
 					eta: t.timeLeft || 0,
 					category: t.categoryName,
-					// Report a "seed limit reached" ratio so Sonarr can remove the
-					// download after import (Completed Download Handling → Remove).
-					// Sonarr only removes a torrent when state is pausedUP/stoppedUP
-					// AND HasReachedSeedLimit: ratio_limit>=0 && (ratio_limit-ratio)
-					// <=0.001. ratio_limit defaults to -2 (use-global) which never
-					// trips since we expose no global max-ratio, so report 0/0
-					// explicitly. (Only consulted for completed pausedUP items —
-					// the state gate short-circuits this for in-progress downloads.)
+					// Report a "seed limit reached" ratio so Sonarr removes the
+					// download after import. Sonarr only removes when state is
+					// pausedUP/stoppedUP AND HasReachedSeedLimit (ratio_limit>=0
+					// && ratio_limit-ratio<=0.001); its -2 (use-global) default
+					// never trips since we expose no global max-ratio, so report
+					// 0/0. Only consulted for completed pausedUP items.
 					ratio: 0,
 					ratio_limit: 0,
 				};
@@ -288,13 +286,12 @@ export class QbittorrentController {
 				return res.status(400).send('No URLs provided');
 			}
 
-			// Sonarr/Radarr send the initial-state flag as a urlencoded form
-			// value, i.e. the STRING "false"/"true" (param name "paused" pre
-			// qBit API 2.11, "stopped" after). A bare `if (paused)` treats the
-			// string "false" as truthy and pauses every download — they then
-			// sit in aMule's queue paused forever, since the *arr client added
-			// them as Start and never calls resume. Only pause on an explicit
-			// true (boolean or string).
+			// Sonarr/Radarr send the initial-state flag as a urlencoded STRING
+			// "false"/"true" (param "paused" pre qBit API 2.11, "stopped" after).
+			// A bare `if (paused)` treats the string "false" as truthy and pauses
+			// every download — they then sit paused in aMule's queue forever,
+			// since the *arr client added them as Start and never resumes. So
+			// pause only on an explicit true (boolean or string).
 			const shouldPause = paused === true || paused === 'true' || stopped === true || stopped === 'true';
 
 			const urlList = typeof urls === 'string' ? urls.split('\n') : urls;
@@ -328,12 +325,11 @@ export class QbittorrentController {
 				if (categoryId) {
 					console.log(`[QbittorrentController] Setting category ID ${categoryId} for hash ${hash}`);
 					// Use MediaProviderService (not amuleService) so the category
-					// is persisted to mularr's DB, not only set in aMule over EC.
-					// getTransfers reports categoryName from the DB record, so
+					// persists to mularr's DB, not only in aMule over EC.
+					// getTransfers reads categoryName from the DB record, so
 					// without this the download surfaces under the DEFAULT
-					// category and Sonarr's torrents/info?category=<TvCat> filter
-					// drops it — it never enters Sonarr's queue. Mirrors what the
-					// setCategory endpoint already does.
+					// category and Sonarr's torrents/info?category= filter drops
+					// it — it never enters the queue. Mirrors the setCategory endpoint.
 					await this.mediaProviderService.setFileCategory(hash, categoryId);
 				}
 
@@ -358,8 +354,8 @@ export class QbittorrentController {
 			if (!hashes) return res.status(400).send('No hashes provided');
 
 			const hashList = hashes.split('|');
-			// Resolve the btih(s) Sonarr sends back to eD2k hashes. Fall back to
-			// the input when no current transfer matches (already eD2k, or the
+			// Resolve the btih(s) Sonarr sends back to transfer hashes, falling
+			// back to the input when no transfer matches (raw hash, or the
 			// download is already gone — cancel is then a harmless no-op).
 			const transfers = await this.mediaProviderService.getTransfers();
 			for (const hash of hashList) {
@@ -391,12 +387,11 @@ export class QbittorrentController {
 			case 7: // Paused
 				return 'pausedDL';
 			case 9: // Completed
-				// pausedUP (completed + not actively seeding), NOT uploading:
-				// both map to Sonarr's "Completed" so import still fires, but
-				// only pausedUP/stoppedUP lets Sonarr remove the download after
-				// import (with Remove Completed Downloads on). 'uploading' tells
-				// Sonarr it's still seeding, so it never removes it. aMule keeps
-				// sharing the file on eD2k regardless of what we report here.
+				// pausedUP, NOT uploading: both map to Sonarr's "Completed" so
+				// import fires, but only pausedUP/stoppedUP lets Sonarr remove
+				// the download after import (with Remove Completed Downloads on).
+				// 'uploading' reads as still seeding, so it's never removed.
+				// aMule keeps sharing the file regardless of what we report.
 				return 'pausedUP';
 			case 3: // Hashing
 			case 2: // Waiting for Hash

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -5,7 +5,7 @@ import { MediaProviderService } from '../services/mediaprovider';
 import { ExtensionsService } from '../services/ExtensionsService';
 import { AmuledService } from '../services/AmuledService';
 import { AuthService } from '../services/AuthService';
-import { hashToBtih, extractHashFromMagnet, clientHashMatchesEd2k } from './qbittorrentMappings';
+import { hashToBtih, extractHashFromMagnet, clientHashMatchesMularrHash } from './qbittorrentMappings';
 
 /**
  * ArrController provides a qBittorrent-compatible API for Sonarr and Radarr.
@@ -87,7 +87,7 @@ export class QbittorrentController {
 		const categories = await this.amuleService.getCategories();
 		const transfers = await this.mediaProviderService.getTransfers();
 		// Sonarr sends the 40-hex btih we advertised; match it back to the eD2k transfer.
-		const tr = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+		const tr = transfers.list.find((t) => clientHashMatchesMularrHash(t.hash, hash));
 
 		if (tr) {
 			const savePath = getCatByName(categories, tr.categoryName ?? '')?.path || config.incomingDir;
@@ -141,7 +141,7 @@ export class QbittorrentController {
 		const transfers = await this.mediaProviderService.getTransfers();
 		for (const hash of hashList) {
 			if (!hash) continue;
-			const match = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+			const match = transfers.list.find((t) => clientHashMatchesMularrHash(t.hash, hash));
 			await this.setCategoryForHash(match?.hash ?? hash, category);
 		}
 		res.send('');
@@ -254,7 +254,7 @@ export class QbittorrentController {
 
 		try {
 			const transfers = await this.mediaProviderService.getTransfers();
-			const tr = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+			const tr = transfers.list.find((t) => clientHashMatchesMularrHash(t.hash, hash));
 			if (!tr) {
 				return res.status(404).send('Torrent not found');
 			}
@@ -364,7 +364,7 @@ export class QbittorrentController {
 			const transfers = await this.mediaProviderService.getTransfers();
 			for (const hash of hashList) {
 				if (!hash) continue;
-				const match = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+				const match = transfers.list.find((t) => clientHashMatchesMularrHash(t.hash, hash));
 				await this.mediaProviderService.sendDownloadCommand(match?.hash ?? hash, 'cancel');
 			}
 			res.send('Ok.');

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -317,7 +317,14 @@ export class QbittorrentController {
 
 				if (categoryId) {
 					console.log(`[QbittorrentController] Setting category ID ${categoryId} for hash ${hash}`);
-					await this.amuleService.setFileCategory(hash, categoryId || 0);
+					// Use MediaProviderService (not amuleService) so the category
+					// is persisted to mularr's DB, not only set in aMule over EC.
+					// getTransfers reports categoryName from the DB record, so
+					// without this the download surfaces under the DEFAULT
+					// category and Sonarr's torrents/info?category=<TvCat> filter
+					// drops it — it never enters Sonarr's queue. Mirrors what the
+					// setCategory endpoint already does.
+					await this.mediaProviderService.setFileCategory(hash, categoryId);
 				}
 
 				if (shouldPause) {

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -273,10 +273,19 @@ export class QbittorrentController {
 		console.log('[QbittorrentController] Add torrent requested');
 		try {
 			// qBittorrent transmits URLs in a field called 'urls'
-			const { urls, category, paused } = req.body;
+			const { urls, category, paused, stopped } = req.body;
 			if (!urls) {
 				return res.status(400).send('No URLs provided');
 			}
+
+			// Sonarr/Radarr send the initial-state flag as a urlencoded form
+			// value, i.e. the STRING "false"/"true" (param name "paused" pre
+			// qBit API 2.11, "stopped" after). A bare `if (paused)` treats the
+			// string "false" as truthy and pauses every download — they then
+			// sit in aMule's queue paused forever, since the *arr client added
+			// them as Start and never calls resume. Only pause on an explicit
+			// true (boolean or string).
+			const shouldPause = paused === true || paused === 'true' || stopped === true || stopped === 'true';
 
 			const urlList = typeof urls === 'string' ? urls.split('\n') : urls;
 
@@ -311,7 +320,7 @@ export class QbittorrentController {
 					await this.amuleService.setFileCategory(hash, categoryId || 0);
 				}
 
-				if (paused) {
+				if (shouldPause) {
 					console.log(`[QbittorrentController] Pausing download for hash ${hash}`);
 					await this.amuleService.pauseDownload(hash);
 				}

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -5,7 +5,7 @@ import { MediaProviderService } from '../services/mediaprovider';
 import { ExtensionsService } from '../services/ExtensionsService';
 import { AmuledService } from '../services/AmuledService';
 import { AuthService } from '../services/AuthService';
-import { hashToBtih, extractHashFromMagnet } from './qbittorrentMappings';
+import { hashToBtih, extractHashFromMagnet, clientHashMatchesEd2k } from './qbittorrentMappings';
 
 /**
  * ArrController provides a qBittorrent-compatible API for Sonarr and Radarr.
@@ -86,7 +86,8 @@ export class QbittorrentController {
 		const config = await this.amuledService.getConfig();
 		const categories = await this.amuleService.getCategories();
 		const transfers = await this.mediaProviderService.getTransfers();
-		const tr = transfers.list.find((t) => t.hash === hash);
+		// Sonarr sends the 40-hex btih we advertised; match it back to the eD2k transfer.
+		const tr = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
 
 		if (tr) {
 			const savePath = getCatByName(categories, tr.categoryName ?? '')?.path || config.incomingDir;
@@ -136,9 +137,12 @@ export class QbittorrentController {
 			return res.status(400).send('Setting category for all torrents is not supported');
 		}
 		const hashList = hashes.split('|');
+		// Resolve the btih(s) Sonarr sends back to eD2k hashes (one transfers fetch).
+		const transfers = await this.mediaProviderService.getTransfers();
 		for (const hash of hashList) {
 			if (!hash) continue;
-			await this.setCategoryForHash(hash, category);
+			const match = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+			await this.setCategoryForHash(match?.hash ?? hash, category);
 		}
 		res.send('');
 	};
@@ -201,7 +205,12 @@ export class QbittorrentController {
 				}
 
 				return {
-					hash: t.hash || 'unknown',
+					// Report the 40-hex btih (sha1 of the eD2k hash), NOT the raw
+					// eD2k hash: it must equal the infohash in the magnet Sonarr
+					// grabbed, or Sonarr can't match this download to its queue
+					// entry (→ no progress, no import). The validator calls above
+					// still use the real eD2k t.hash internally.
+					hash: t.hash ? hashToBtih(t.hash) : 'unknown',
 					name: t.name || 'Unknown',
 					size: t.size || 0,
 					progress: t.progress || 0,
@@ -235,7 +244,7 @@ export class QbittorrentController {
 
 		try {
 			const transfers = await this.mediaProviderService.getTransfers();
-			const tr = transfers.list.find((t) => t.hash === hash);
+			const tr = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
 			if (!tr) {
 				return res.status(404).send('Torrent not found');
 			}
@@ -323,10 +332,14 @@ export class QbittorrentController {
 			if (!hashes) return res.status(400).send('No hashes provided');
 
 			const hashList = hashes.split('|');
+			// Resolve the btih(s) Sonarr sends back to eD2k hashes. Fall back to
+			// the input when no current transfer matches (already eD2k, or the
+			// download is already gone — cancel is then a harmless no-op).
+			const transfers = await this.mediaProviderService.getTransfers();
 			for (const hash of hashList) {
-				if (hash) {
-					await this.mediaProviderService.sendDownloadCommand(hash, 'cancel');
-				}
+				if (!hash) continue;
+				const match = transfers.list.find((t) => clientHashMatchesEd2k(t.hash, hash));
+				await this.mediaProviderService.sendDownloadCommand(match?.hash ?? hash, 'cancel');
 			}
 			res.send('Ok.');
 		} catch (e: any) {

--- a/backend/src/controllers/QbittorrentController.ts
+++ b/backend/src/controllers/QbittorrentController.ts
@@ -225,6 +225,16 @@ export class QbittorrentController {
 					added_on: Math.floor(Date.now() / 1000),
 					eta: t.timeLeft || 0,
 					category: t.categoryName,
+					// Report a "seed limit reached" ratio so Sonarr can remove the
+					// download after import (Completed Download Handling → Remove).
+					// Sonarr only removes a torrent when state is pausedUP/stoppedUP
+					// AND HasReachedSeedLimit: ratio_limit>=0 && (ratio_limit-ratio)
+					// <=0.001. ratio_limit defaults to -2 (use-global) which never
+					// trips since we expose no global max-ratio, so report 0/0
+					// explicitly. (Only consulted for completed pausedUP items —
+					// the state gate short-circuits this for in-progress downloads.)
+					ratio: 0,
+					ratio_limit: 0,
 				};
 			});
 
@@ -381,7 +391,13 @@ export class QbittorrentController {
 			case 7: // Paused
 				return 'pausedDL';
 			case 9: // Completed
-				return 'uploading';
+				// pausedUP (completed + not actively seeding), NOT uploading:
+				// both map to Sonarr's "Completed" so import still fires, but
+				// only pausedUP/stoppedUP lets Sonarr remove the download after
+				// import (with Remove Completed Downloads on). 'uploading' tells
+				// Sonarr it's still seeding, so it never removes it. aMule keeps
+				// sharing the file on eD2k regardless of what we report here.
+				return 'pausedUP';
 			case 3: // Hashing
 			case 2: // Waiting for Hash
 				return 'checkingDL';

--- a/backend/src/controllers/qbittorrentMappings.ts
+++ b/backend/src/controllers/qbittorrentMappings.ts
@@ -12,14 +12,12 @@ export function hashToBtih(hash: string): string {
 }
 
 /**
- * True if `clientHash` — a hash received from a qBittorrent API client such as
- * Sonarr/Radarr — refers to the transfer identified by `mularrHash`. The
- * transfer hash is provider-specific and must NOT be assumed to be eD2k: it is
- * a 32-hex eD2k hash for aMule downloads, or a custom hash minted by mularr for
- * Telegram (and future) providers. Clients only ever know the fake 40-hex btih
- * we advertise (sha1 of that hash), which is one-way, so the match is done
- * forward: the client hash matches if it equals the transfer hash directly or
- * its 40-hex btih. Case-insensitive.
+ * True if `clientHash` (from a qBittorrent client like Sonarr/Radarr) refers to
+ * the transfer `mularrHash`. The transfer hash is provider-specific — a 32-hex
+ * eD2k hash for aMule, or a custom hash minted for Telegram/future providers —
+ * so never assume eD2k. Clients only know the fake 40-hex btih we advertise
+ * (sha1 of the hash, one-way), so match forward: clientHash equals the transfer
+ * hash directly or its btih. Case-insensitive.
  */
 export function clientHashMatchesMularrHash(mularrHash: string | undefined, clientHash: string): boolean {
 	if (!mularrHash || !clientHash) return false;

--- a/backend/src/controllers/qbittorrentMappings.ts
+++ b/backend/src/controllers/qbittorrentMappings.ts
@@ -13,16 +13,18 @@ export function hashToBtih(hash: string): string {
 
 /**
  * True if `clientHash` — a hash received from a qBittorrent API client such as
- * Sonarr/Radarr — refers to the transfer identified by eD2k hash `ed2kHash`.
- * Clients only ever know the fake 40-hex btih we advertise (sha1 of the eD2k
- * hash), which is one-way, so the match is done forward: the client hash
- * matches if it equals the eD2k hash directly (32-hex — internal/legacy
- * callers) or its btih (40-hex). Case-insensitive.
+ * Sonarr/Radarr — refers to the transfer identified by `mularrHash`. The
+ * transfer hash is provider-specific and must NOT be assumed to be eD2k: it is
+ * a 32-hex eD2k hash for aMule downloads, or a custom hash minted by mularr for
+ * Telegram (and future) providers. Clients only ever know the fake 40-hex btih
+ * we advertise (sha1 of that hash), which is one-way, so the match is done
+ * forward: the client hash matches if it equals the transfer hash directly or
+ * its 40-hex btih. Case-insensitive.
  */
-export function clientHashMatchesEd2k(ed2kHash: string | undefined, clientHash: string): boolean {
-	if (!ed2kHash || !clientHash) return false;
+export function clientHashMatchesMularrHash(mularrHash: string | undefined, clientHash: string): boolean {
+	if (!mularrHash || !clientHash) return false;
 	const c = clientHash.toLowerCase();
-	return ed2kHash.toLowerCase() === c || hashToBtih(ed2kHash) === c;
+	return mularrHash.toLowerCase() === c || hashToBtih(mularrHash) === c;
 }
 
 export function hashToFakeMagnet(hash: string): string {

--- a/backend/src/controllers/qbittorrentMappings.ts
+++ b/backend/src/controllers/qbittorrentMappings.ts
@@ -1,8 +1,28 @@
 import { createHash } from 'crypto';
 
 export function hashToBtih(hash: string): string {
-	const btih = createHash('sha1').update(hash).digest('hex'); // 40 chars hex
+	// Normalize to lowercase before hashing so the btih is identical whether it
+	// is computed from a search-result hash (used to build the magnet Sonarr
+	// grabs) or from a transfer hash (reported in torrents/info). Both must hash
+	// to the same 40-hex id or Sonarr cannot reconcile the grab with the
+	// download. No-op for the existing magnet path, whose input is already
+	// lowercase hex.
+	const btih = createHash('sha1').update(hash.toLowerCase()).digest('hex'); // 40 chars hex
 	return btih;
+}
+
+/**
+ * True if `clientHash` — a hash received from a qBittorrent API client such as
+ * Sonarr/Radarr — refers to the transfer identified by eD2k hash `ed2kHash`.
+ * Clients only ever know the fake 40-hex btih we advertise (sha1 of the eD2k
+ * hash), which is one-way, so the match is done forward: the client hash
+ * matches if it equals the eD2k hash directly (32-hex — internal/legacy
+ * callers) or its btih (40-hex). Case-insensitive.
+ */
+export function clientHashMatchesEd2k(ed2kHash: string | undefined, clientHash: string): boolean {
+	if (!ed2kHash || !clientHash) return false;
+	const c = clientHash.toLowerCase();
+	return ed2kHash.toLowerCase() === c || hashToBtih(ed2kHash) === c;
 }
 
 export function hashToFakeMagnet(hash: string): string {

--- a/backend/src/controllers/qbittorrentMappings.ts
+++ b/backend/src/controllers/qbittorrentMappings.ts
@@ -1,11 +1,10 @@
 import { createHash } from 'crypto';
 
 export function hashToBtih(hash: string): string {
-	// Normalize to lowercase before hashing so the btih is identical whether it
-	// is computed from a search-result hash (used to build the magnet Sonarr
-	// grabs) or from a transfer hash (reported in torrents/info). Both must hash
-	// to the same 40-hex id or Sonarr cannot reconcile the grab with the
-	// download. No-op for the existing magnet path, whose input is already
+	// Lowercase before hashing so the btih is identical whether computed from a
+	// search-result hash (the magnet Sonarr grabs) or a transfer hash (reported
+	// in torrents/info) — both must hash to the same 40-hex id or Sonarr can't
+	// reconcile the grab with the download. No-op for the magnet path, already
 	// lowercase hex.
 	const btih = createHash('sha1').update(hash.toLowerCase()).digest('hex'); // 40 chars hex
 	return btih;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -125,7 +125,7 @@ async function main() {
 	app.use('/api/extensions', withAuth(extensionsRoutes()));
 	app.use('/api/telegram', withAuth(telegramRoutes()));
 	app.use('/api/as-qbittorrent/api/v2', qbittorrentRoutes()); // manages its own auth internally
-	app.use('/api/as-torznab-indexer', withAuth(indexerRoutes())); // Torznab indexer for Sonarr/Radarr
+	app.use('/api/as-torznab-indexer', withAuth(indexerRoutes())); // Torznab indexer for Sonarr/Radarr/Lidarr
 	app.use('/api/blacklist', withAuth(blacklistRoutes()));
 
 	// -- Serve static files from the 'public' folder ------------------------------

--- a/backend/src/services/AmuleService.ts
+++ b/backend/src/services/AmuleService.ts
@@ -86,10 +86,9 @@ export class AmuleService {
 	private readonly password = process.env.AMULE_PASSWORD || 'secret';
 	// timeout: hard-bound each EC round-trip. Without it a half-open socket
 	// (write ok, no reply, no FIN/RST — e.g. a VPN/container blackhole) leaves
-	// client calls pending forever, hanging the indexer's gather loop past its
-	// 12s cap and leaking the request. A timed-out call throws and is caught by
-	// the existing try/catch (falls back to amulecmd or returns progress:0/
-	// empty), so the gather loop keeps polling and its cap actually fires.
+	// calls pending forever, hanging the indexer's gather loop past its cap and
+	// leaking the request. A timed-out call throws into the existing try/catch
+	// (falls back to amulecmd or returns empty), so the loop keeps polling.
 	private readonly client = new AmuleClient({ host: this.host, port: parseInt(this.port), password: this.password, timeout: 4000 });
 	private readonly amulecmdService: AmulecmdService | null = null;
 	private db: MainDB;

--- a/backend/src/services/AmuleService.ts
+++ b/backend/src/services/AmuleService.ts
@@ -84,7 +84,13 @@ export class AmuleService {
 	private readonly host = process.env.AMULE_HOST || 'localhost';
 	private readonly port = process.env.AMULE_PORT || '4712';
 	private readonly password = process.env.AMULE_PASSWORD || 'secret';
-	private readonly client = new AmuleClient({ host: this.host, port: parseInt(this.port), password: this.password });
+	// timeout: hard-bound each EC round-trip. Without it a half-open socket
+	// (write ok, no reply, no FIN/RST — e.g. a VPN/container blackhole) leaves
+	// client calls pending forever, hanging the indexer's gather loop past its
+	// 12s cap and leaking the request. A timed-out call throws and is caught by
+	// the existing try/catch (falls back to amulecmd or returns progress:0/
+	// empty), so the gather loop keeps polling and its cap actually fires.
+	private readonly client = new AmuleClient({ host: this.host, port: parseInt(this.port), password: this.password, timeout: 4000 });
 	private readonly amulecmdService: AmulecmdService | null = null;
 	private db: MainDB;
 


### PR DESCRIPTION
This pull request introduces several key improvements.  It builds and expands the indexer to support Lidarr (music) alongside Sonarr and Radarr. It also enhances the robustness of the aMule service integration and improves compatibility with cross-platform builds. Below are the most important changes grouped by theme:

**Indexer Enhancements for Lidarr (Music):**

* Extended the Torznab-compatible indexer to support Lidarr/music searches by handling `music` action type and new parameters (`artist`, `album`), and improved query handling for music searches. [[1]](diffhunk://#diff-fe5ea696b3697a68802f0c03a6890bf6c3e902a077dd6494654c30c641a06ac0L7-R40) [[2]](diffhunk://#diff-fe5ea696b3697a68802f0c03a6890bf6c3e902a077dd6494654c30c641a06ac0R56-R61)
* Updated the indexer’s capabilities XML to advertise `audio-search` and `music-search` support, and added an Audio category for music results. [[1]](diffhunk://#diff-fe5ea696b3697a68802f0c03a6890bf6c3e902a077dd6494654c30c641a06ac0R154-R174) [[2]](diffhunk://#diff-fe5ea696b3697a68802f0c03a6890bf6c3e902a077dd6494654c30c641a06ac0R184-R188)
* Updated API routes, RSS feed descriptions, and documentation comments to reference Lidarr support alongside Sonarr and Radarr. [[1]](diffhunk://#diff-fe5ea696b3697a68802f0c03a6890bf6c3e902a077dd6494654c30c641a06ac0L150-R230) [[2]](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324L128-R128)

**Search Result Robustness and Completeness:**

* Improved the search result gathering logic to poll until the result set is stable (not just based on progress), ensuring more complete results are returned to clients.

**aMule Service Robustness:**

* Set a timeout for aMule client calls to prevent indefinite hangs in case of network issues, ensuring the indexer’s polling loop remains responsive.

**Indexer Search Behavior Adjustments:**

* Changed TV search logic to avoid appending season/episode to the search query, relying on Sonarr to filter results, which yields more comprehensive candidate lists.