### PR TITLE
 improve Torznab search

### DIFF
--- a/backend/src/controllers/IndexerController.ts
+++ b/backend/src/controllers/IndexerController.ts
@@ -66,20 +66,26 @@ export class IndexerController {
 				return this.renderRss(res, [], cat as string);
 			}
 
-			// tvsearch: search by the title in `q` only. season/ep arrive as
-			// separate Torznab params, not inside `q`; appending them narrows
-			// the eD2k query against the network's inconsistent episode naming
-			// and loses real content. Sonarr does the episode/language/quality
-			// matching itself, rejecting releases that don't fit, so we let all
-			// candidates flow back. (season/ep stay destructured for logging.)
-			// Trade-off: a tvsearch returns every episode's releases; automatic
-			// search only grabs matches, interactive greys out the rest.
-
 			// Radarr/Sonarr "Test" often sends 't=movie' or 't=search' without 'q'.
 			if (!queryStr.trim()) {
 				console.log(`[Indexer] Empty query for action ${t}, returning empty valid RSS for Test compatibility`);
 				return this.renderRss(res, [], cat as string);
 			}
+
+			// tvsearch: season/ep arrive as separate params. Both back-ends match
+			// whole tokens and read uppercase OR as boolean, so OR the two common
+			// spellings (NxMM, SnnEmm); rarer forms fall to the *arr's own filter.
+			if (t === 'tvsearch' && typeof season === 'string' && typeof ep === 'string' && /^\d+$/.test(season) && /^\d+$/.test(ep)) {
+				const s = parseInt(season, 10);
+				const e = parseInt(ep, 10);
+				const pad2 = (n: number) => String(n).padStart(2, '0');
+				const title = queryStr;
+				queryStr = `${title} ${s}x${pad2(e)} OR ${title} S${pad2(s)}E${pad2(e)}`;
+			}
+
+			// Releases often drop apostrophes (e.g. "Widow's Bay" -> "Widows Bay").
+			// Done here so every search type benefits.
+			queryStr = this.expandApostrophes(queryStr);
 
 			try {
 				await this.mediaProviderService.startSearch(queryStr);
@@ -132,6 +138,11 @@ export class IndexerController {
 
 		res.status(400).send('Unknown action');
 	};
+
+	private expandApostrophes(query: string): string {
+		const stripped = query.replace(/['’]/g, '');
+		return stripped === query || stripped.trim() === '' ? query : `${query} OR ${stripped}`;
+	}
 
 	private getCapabilities(res: Response) {
 		res.header('Content-Type', 'application/xml');

--- a/backend/src/controllers/IndexerController.ts
+++ b/backend/src/controllers/IndexerController.ts
@@ -72,15 +72,11 @@ export class IndexerController {
 				return this.renderRss(res, [], cat as string);
 			}
 
-			// tvsearch: season/ep arrive as separate params. Both back-ends match
-			// whole tokens and read uppercase OR as boolean, so OR the two common
-			// spellings (NxMM, SnnEmm); rarer forms fall to the *arr's own filter.
+			// tvsearch: search by title alone, then filter names locally by
+			// season/ep (see filterByEpisode).
+			let epFilter: { season: number; ep: number } | undefined;
 			if (t === 'tvsearch' && typeof season === 'string' && typeof ep === 'string' && /^\d+$/.test(season) && /^\d+$/.test(ep)) {
-				const s = parseInt(season, 10);
-				const e = parseInt(ep, 10);
-				const pad2 = (n: number) => String(n).padStart(2, '0');
-				const title = queryStr;
-				queryStr = `${title} ${s}x${pad2(e)} OR ${title} S${pad2(s)}E${pad2(e)}`;
+				epFilter = { season: parseInt(season, 10), ep: parseInt(ep, 10) };
 			}
 
 			// Releases often drop apostrophes (e.g. "Widow's Bay" -> "Widows Bay").
@@ -121,8 +117,9 @@ export class IndexerController {
 
 				const results = await this.mediaProviderService.getSearchResults();
 
+				let list = epFilter ? this.filterByEpisode(results.list, epFilter.season, epFilter.ep) : results.list;
+
 				// Apply offset and limit
-				let list = results.list;
 				const start = parseInt(offset as string) || 0;
 				const size = parseInt(limit as string) || 100;
 				list = list.slice(start, start + size);
@@ -138,6 +135,22 @@ export class IndexerController {
 
 		res.status(400).send('Unknown action');
 	};
+
+	private filterByEpisode(results: MediaSearchResult[], season: number, ep: number): MediaSearchResult[] {
+		// 0* absorbs zero-padding (S01E07 == S1E7); \s? allows a split SxxEyy.
+		const patterns = [/\bs0*(\d+)\s?e0*(\d+)\b/i, /\b0*(\d+)x0*(\d+)\b/i];
+		return results.filter((r) => {
+			// Normalize dot/underscore separators so word boundaries hold.
+			const name = r.name.replace(/[._]/g, ' ');
+			for (const pattern of patterns) {
+				const m = name.match(pattern);
+				if (m && parseInt(m[1], 10) === season && parseInt(m[2], 10) === ep) {
+					return true;
+				}
+			}
+			return false;
+		});
+	}
 
 	private expandApostrophes(query: string): string {
 		const stripped = query.replace(/['’]/g, '');

--- a/backend/src/services/db/TelegramIndexerDB.ts
+++ b/backend/src/services/db/TelegramIndexerDB.ts
@@ -53,6 +53,22 @@ export interface ActiveDownloadRow {
 	error_message?: string | null;
 }
 
+// Quote each term so FTS5-special chars (' - : & ( ) ") match literally
+// instead of throwing; keep uppercase OR/AND/NOT as operators. Drops
+// punctuation-only terms; null when nothing usable remains.
+export function toFtsMatchExpr(query: string): string | null {
+	const expr = query
+		.split(/\s+/)
+		.map((tok) => {
+			if (tok === 'OR' || tok === 'AND' || tok === 'NOT') return tok;
+			if (!/[\p{L}\p{N}]/u.test(tok)) return '';
+			return `"${tok.replace(/"/g, '""')}"`;
+		})
+		.filter((tok) => tok.length > 0)
+		.join(' ');
+	return expr.length > 0 ? expr : null;
+}
+
 export class TelegramIndexerDB {
 	private db: Database.Database;
 
@@ -292,13 +308,15 @@ export class TelegramIndexerDB {
 	}
 
 	public search(query: string, limit: number = 20): MessageRow[] {
+		const match = toFtsMatchExpr(query);
+		if (match === null) return [];
 		return this.db
 			.prepare(
 				`
 				SELECT * FROM messages_fts WHERE messages_fts MATCH ? ORDER BY rank LIMIT ?
 			`
 			)
-			.all(query, limit) as MessageRow[];
+			.all(match, limit) as MessageRow[];
 	}
 
 	public getMessage(chatId: string, messageId: number): MessageRow | undefined {
@@ -325,6 +343,9 @@ export class TelegramIndexerDB {
 		// query so callers in pagination loops don't starve other async work.
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
+		const match = toFtsMatchExpr(query);
+		if (match === null) return { rows: [], nextCursor: null };
+
 		const rows = this.db
 			.prepare(
 				`
@@ -338,7 +359,7 @@ export class TelegramIndexerDB {
 				LIMIT ?
 			`
 			)
-			.all(query, cursorId, limit) as MessageRow[];
+			.all(match, cursorId, limit) as MessageRow[];
 
 		const nextCursor = rows.length === limit ? rows[rows.length - 1].id : null;
 		return { rows, nextCursor };


### PR DESCRIPTION
Bundles a few Torznab search-matching improvements. 
- TV search query: build the eD2k query from the title plus the episode in both common notations (Title 1x02 OR Title S01E02), so releases named either way are matched
- Apostrophe variant: add an apostrophe-stripped title alternative (OR’d in) so releases that drop apostrophes still match, across all search types
- FTS5: sanitize the Telegram search query; quote special chars so they match literally instead of throwing, and skip empty/punctuation-only queries