### PR TITLE
Fix: Support Telegram 2FA and prevent amuled crash on macOS

### DIFF
--- a/backend/src/services/AmuledService.ts
+++ b/backend/src/services/AmuledService.ts
@@ -190,7 +190,7 @@ export class AmuledService {
 			}
 		}
 		console.log('Starting aMule daemon...');
-		const child = spawn('amuled', ['-c', this.configDir, '-f'], {
+		const child = spawn('amuled', ['-c', this.configDir], {
 			detached: true,
 			stdio: 'ignore',
 		});

--- a/backend/src/services/TelegramIndexerService.ts
+++ b/backend/src/services/TelegramIndexerService.ts
@@ -177,9 +177,15 @@ export class TelegramIndexerService {
 		}
 
 		try {
-			await (this.client as any).signIn({
-				password: password,
-			});
+			await this.client.signInWithPassword(
+				{ apiId: (this.client as any).apiId, apiHash: (this.client as any).apiHash },
+				{
+					password: async () => password,
+					onError: (err: any) => {
+						throw err;
+					},
+				}
+			);
 
 			this.onLoginSuccess();
 		} catch (e: any) {


### PR DESCRIPTION
### Support for Telegram 2FA (2-Step Verification) and macOS amuled crash fix

Hi! I was testing Mularr on macOS and ran into a couple of issues that I managed to fix locally.

**1. Telegram Indexer: Support for 2-Step Verification (Password)**
When trying to log in to Telegram via the frontend, the authentication process was throwing a `SESSION_PASSWORD_NEEDED` error if the Telegram account had 2-Step Verification enabled. I added `signInWithPassword()` to handle this case properly.

**2. aMule Daemon: Crash on macOS (Segmentation Fault)**
When starting the backend, `amuled` was constantly crashing on macOS with a Segmentation Fault (`wxGet_wxConvLibcPtr`). This happens because the `-f` (fork to background) flag in `amuled` is buggy on macOS when using `wxWidgets`. Since `spawn()` in Node.js already runs the process detached in the background, the `-f` flag is redundant, so I removed it.

**3. Note on macOS connection timeouts (IPv6 vs IPv4)**
By default, Node.js on macOS resolves `localhost` to `::1` (IPv6), but `amuled` listens on `0.0.0.0` (IPv4). This causes ECONNREFUSED/Timeouts. Setting `AMULE_HOST=127.0.0.1` in the `.env` file bypasses this issue.
