### PR TITLE
Fix bundled aMule EC password synchronization

### DIFF
--- a/.devcontainer/setup-amule.sh
+++ b/.devcontainer/setup-amule.sh
@@ -23,6 +23,8 @@ echo "aMule ${AMULE_VERSION} installation complete."
 # -- Configuration Setup --
 # Dev uses default home directory for config
 CONF_DIR="$HOME/.aMule"
+EC_PASSWORD="${AMULE_PASSWORD:-secret}"
+EC_PASSWORD_HASH="$(printf '%s' "$EC_PASSWORD" | node -e "const crypto = require('crypto'); const chunks = []; process.stdin.on('data', (chunk) => chunks.push(chunk)); process.stdin.on('end', () => process.stdout.write(crypto.createHash('md5').update(Buffer.concat(chunks)).digest('hex')));")"
 mkdir -p "$CONF_DIR"
 
 if [ ! -f "$CONF_DIR/amule.conf" ]; then
@@ -35,7 +37,7 @@ Nick=Mularr
 AcceptExternalConnections=1
 ECAddress=127.0.0.1
 ECPort=4712
-ECPassword=5ebe2294ecd0e0f08eab7690d2a6ee69
+ECPassword=$EC_PASSWORD_HASH
 EOF
 fi
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -52,8 +52,8 @@ services:
             - API_KEY= # example: supersecretapikey. Used to authenticate API requests from other apps without login (needed for torznab integration, for example. API_KEY can also be used as password with the username 'apikey' for the qbittorrent api)
             - JWT_SECRET= # example: supersecretjwtkey. Used to sign JSON Web Tokens for API authentication (if not set, a random secret will be generated on startup, which means any existing tokens will become invalid after a restart)
 
-            # Customize how Mularr connects to aMule via EC (most likely you don't need to set these)
-            # Set these ONLY if Mularr will connect to an external aMule instance
+            # AMULE_PASSWORD configures both Mularr and the bundled aMule daemon.
+            # AMULE_HOST and AMULE_PORT are only needed for an external aMule instance.
             - AMULE_HOST=localhost
             - AMULE_PORT=4712
             - AMULE_PASSWORD=secret

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,52 @@
 #!/bin/sh
 set -e
 
-# Define generic password hash for 'secret' if not provided?
-# For simplicity we hardcode the hash for 'secret' to match defaults.
-# MD5("secret") = 5ebe2294ecd0e0f08eab7690d2a6ee69
-
 CONF_DIR="${AMULE_CONFIG_DIR:-$HOME/.aMule}"
 INCOMING_DIR="${AMULE_INCOMING_DIR:-$CONF_DIR/Incoming}"
 TEMP_DIR="${AMULE_TEMP_DIR:-$CONF_DIR/Temp}"
+EC_PASSWORD="${AMULE_PASSWORD:-secret}"
+EC_PASSWORD_HASH="$(printf '%s' "$EC_PASSWORD" | node -e "const crypto = require('crypto'); const chunks = []; process.stdin.on('data', (chunk) => chunks.push(chunk)); process.stdin.on('end', () => process.stdout.write(crypto.createHash('md5').update(Buffer.concat(chunks)).digest('hex')));")"
+
+sync_ec_password() {
+    conf_path="$1"
+    temp_path="${conf_path}.tmp"
+
+    cp -p "$conf_path" "$temp_path"
+    awk -v password_hash="$EC_PASSWORD_HASH" '
+        BEGIN {
+            in_external_connect = 0
+            password_written = 0
+        }
+        /^\[/ {
+            if (in_external_connect && !password_written) {
+                print "ECPassword=" password_hash
+                password_written = 1
+            }
+            in_external_connect = ($0 == "[ExternalConnect]")
+        }
+        in_external_connect && /^ECPassword=/ {
+            if (!password_written) {
+                print "ECPassword=" password_hash
+                password_written = 1
+            }
+            next
+        }
+        {
+            print
+        }
+        END {
+            if (in_external_connect && !password_written) {
+                print "ECPassword=" password_hash
+            } else if (!password_written) {
+                print ""
+                print "[ExternalConnect]"
+                print "ECPassword=" password_hash
+            }
+        }
+    ' "$conf_path" > "$temp_path"
+
+    mv "$temp_path" "$conf_path"
+}
 
 mkdir -p "$CONF_DIR"
 mkdir -p "$INCOMING_DIR"
@@ -25,9 +64,11 @@ TempDir=$TEMP_DIR
 AcceptExternalConnections=1
 ECAddress=127.0.0.1
 ECPort=4712
-ECPassword=5ebe2294ecd0e0f08eab7690d2a6ee69
+ECPassword=$EC_PASSWORD_HASH
 EOF
 else
+    sync_ec_password "$CONF_DIR/amule.conf"
+
     # Update directories if env vars are provided and file exists
     if [ -n "$AMULE_INCOMING_DIR" ]; then
         sed -i "s|^IncomingDir=.*|IncomingDir=$AMULE_INCOMING_DIR|" "$CONF_DIR/amule.conf"

--- a/tests/entrypoint-config.test.sh
+++ b/tests/entrypoint-config.test.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+assert_password_hash() {
+    conf_path="$1"
+    expected_hash="$2"
+    actual_hash="$(sed -n 's/^ECPassword=//p' "$conf_path")"
+
+    if [ "$actual_hash" != "$expected_hash" ]; then
+        echo "Expected ECPassword=$expected_hash, got ECPassword=$actual_hash" >&2
+        exit 1
+    fi
+}
+
+default_dir="$TEST_ROOT/default"
+(
+    unset AMULE_PASSWORD
+    AMULE_CONFIG_DIR="$default_dir" "$REPO_DIR/entrypoint.sh" true
+)
+assert_password_hash "$default_dir/amule.conf" "5ebe2294ecd0e0f08eab7690d2a6ee69"
+
+custom_dir="$TEST_ROOT/custom"
+AMULE_CONFIG_DIR="$custom_dir" AMULE_PASSWORD="custom-secret" "$REPO_DIR/entrypoint.sh" true
+assert_password_hash "$custom_dir/amule.conf" "ddc33abcbec51fd4de296be5cf1230fe"
+
+persisted_dir="$TEST_ROOT/persisted"
+mkdir -p "$persisted_dir"
+cat > "$persisted_dir/amule.conf" <<'EOF'
+[eMule]
+Nick=Mularr
+
+[ExternalConnect]
+AcceptExternalConnections=1
+ECAddress=127.0.0.1
+ECPort=4712
+ECPassword=5ebe2294ecd0e0f08eab7690d2a6ee69
+EOF
+AMULE_CONFIG_DIR="$persisted_dir" AMULE_PASSWORD="rotated-password" "$REPO_DIR/entrypoint.sh" true
+assert_password_hash "$persisted_dir/amule.conf" "a43dd3d72b3ec93171c53da0075fefb8"
+
+echo "entrypoint EC password tests passed"


### PR DESCRIPTION
## Summary

- derive the bundled aMule `ECPassword` hash from the same `AMULE_PASSWORD` plaintext used by the backend
- update persisted `amule.conf` files on startup so password rotations do not leave the daemon and EC client out of sync
- keep devcontainer generation and Compose documentation aligned with the runtime behavior
- add regression coverage for default, custom, and rotated passwords

## Verification

- `tests/entrypoint-config.test.sh`
- `sh -n entrypoint.sh`
- `bash -n .devcontainer/setup-amule.sh`
- `docker build -t mularr-batch70-typescript-02:fixed .`
- clean-volume container with `AMULE_PASSWORD=custom-secret`: `/api/media/transfers` succeeded and generated `ECPassword=ddc33abcbec51fd4de296be5cf1230fe`
- persisted-volume rotation from the old hardcoded hash to `custom-secret`: `/api/media/transfers` succeeded with no EC authentication errors

On current `main` (`v0.16.2`), the default `secret` path already authenticates successfully. The remaining reproducible failure was setting `AMULE_PASSWORD`, which changed the backend credential while generated and persisted bundled configs retained the hardcoded hash for `secret`.

Fixes #20